### PR TITLE
fix: Correct map coordinate system to fix zoom scaling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     const map = L.map('map', {
-        // crs: L.CRS.Simple, // No longer needed for tile map
+        crs: L.CRS.Simple,
     }).setView([3222, 3215], -2); // Center on Lumbridge
 
     const tileUrl = 'https://mejrs.github.io/layers_rs3/map_squares/-1/{z}/0_{x}_{y}.png';


### PR DESCRIPTION
This commit fixes a bug where the map and its markers would not scale correctly when zooming.

The issue was caused by using the default Leaflet CRS (EPSG:3857), which is designed for geographical maps, instead of the appropriate CRS for a flat game map.

The `L.map` initialization has been updated to use `crs: L.CRS.Simple`. This ensures that the tile layers and markers are scaled correctly in a simple Cartesian coordinate system.